### PR TITLE
Feat/header enhancements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -710,9 +710,10 @@ function App() {
         </div>
 
         {/* Footer */}
-        <footer className='mt-16 py-2 border-t'>
+        <footer className='mt-16 py-6 border-t'> {/* Increased padding */}
           <div className='max-w-4xl mx-auto px-4'>
-            <div className='flex flex-col md:flex-row items-center justify-between gap-4'>
+            {/* Changed justify-between to justify-center */}
+            <div className='flex flex-col md:flex-row items-center justify-center gap-4'>
               <div className='flex items-center gap-2 text-sm text-muted-foreground'>
                 <span>Built with</span>
                 <Heart className='h-4 w-4 text-red-500 fill-current' />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useCallback } from 'react';
-import { Trash2, Download, CheckCircle, Archive, Server, Monitor, Copy, Check, Github, Heart } from 'lucide-react';
+import { Trash2, Download, CheckCircle, Archive, Server, Monitor, Copy, Check, Github, Heart, Sun, Moon } from 'lucide-react';
 import {
   DataGrid,
   DataGridColumn,
@@ -43,6 +43,21 @@ const statusOptions = [
 const StatusSelectInput = createSelectEditComponent<UserType>(statusOptions);
 
 function App() {
+  // Theme state
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
+  };
+
   // Demo state for server-side vs client-side
   const [isServerSide, setIsServerSide] = useState(false);
 
@@ -493,8 +508,28 @@ function App() {
     <div className='min-h-screen bg-background p-8'>
       <div className='max-w-7xl mx-auto space-y-8'>
         {/* Header */}
-        <div className='text-center space-y-4'>
-          <h1 className='text-4xl font-bold tracking-tight'>shadcn/ui DataGrid Component</h1>
+        <div className='relative text-center space-y-4'> {/* Added relative positioning */}
+          {/* Container for icons in the top right */}
+          <div className='absolute top-0 right-0 flex items-center p-2 space-x-2'>
+            <Button
+              variant='ghost'
+              size='icon'
+              onClick={toggleTheme}
+              aria-label='Toggle theme'
+              className='text-muted-foreground hover:text-foreground'
+            >
+              {theme === 'light' ? <Moon className='h-5 w-5' /> : <Sun className='h-5 w-5' />}
+            </Button>
+            <a
+              href='https://github.com/abaktiar/datagrid-shadcn'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-muted-foreground hover:text-foreground'
+            >
+              <Github className='h-6 w-6' />
+            </a>
+          </div>
+          <h1 className='text-4xl font-bold tracking-tight pt-10'>shadcn/ui DataGrid Component</h1> {/* Adjusted padding-top */}
           <p className='text-xl text-muted-foreground max-w-3xl mx-auto'>
             A feature-rich, composable datagrid built with TanStack Table v8, shadcn/ui, and Tailwind CSS v4. Supports
             sorting, filtering, pagination, row selection, bulk actions, and inline cell editing.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -728,16 +728,7 @@ function App() {
                 <span className='font-medium text-foreground'>AI✨</span>
               </div>
 
-              <div className='flex items-center gap-4'>
-                <a
-                  href='https://github.com/abaktiar/datagrid-shadcn'
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-foreground bg-background border rounded-lg hover:bg-muted transition-colors'>
-                  <Github className='h-4 w-4' />
-                  View on GitHub
-                </a>
-              </div>
+              {/* The GitHub link previously here has been removed */}
             </div>
           </div>
         </footer>

--- a/src/components/data-grid/data-grid-body.tsx
+++ b/src/components/data-grid/data-grid-body.tsx
@@ -114,8 +114,8 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
               aria-rowindex={virtualItem.index + 2} // +2 because header is row 1
               aria-selected={row.getIsSelected()}
               className={cn(
-                'border-b border-border hover:bg-muted/30 data-[state=selected]:bg-blue-50',
-                row.getIsSelected() && 'bg-blue-50 border-blue-200'
+                'border-b border-border hover:bg-muted/30', // Base styling
+                row.getIsSelected() && 'bg-accent/60 dark:bg-accent/60 text-accent-foreground' // New style for selected rows
               )}
               style={{
                 position: 'absolute',
@@ -164,8 +164,8 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
           aria-rowindex={row.index + 2} // +2 because header is row 1
           aria-selected={row.getIsSelected()}
           className={cn(
-            'border-b border-border hover:bg-muted/30 data-[state=selected]:bg-blue-50',
-            row.getIsSelected() && 'bg-blue-50 border-blue-200'
+            'border-b border-border hover:bg-muted/30', // Base styling
+            row.getIsSelected() && 'bg-accent/60 dark:bg-accent/60 text-accent-foreground' // New style for selected rows
           )}>
           {row.getVisibleCells().map((cell) => (
             <CellContextMenu

--- a/src/components/data-grid/data-grid-body.tsx
+++ b/src/components/data-grid/data-grid-body.tsx
@@ -115,7 +115,7 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
               aria-selected={row.getIsSelected()}
               className={cn(
                 'border-b border-border hover:bg-muted/30', // Base styling
-                row.getIsSelected() && 'bg-accent/60 dark:bg-accent/60 text-accent-foreground' // New style for selected rows
+                row.getIsSelected() && 'bg-blue-50 text-slate-900 dark:bg-accent/60 dark:text-accent-foreground' // New distinct styles
               )}
               style={{
                 position: 'absolute',
@@ -165,7 +165,7 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
           aria-selected={row.getIsSelected()}
           className={cn(
             'border-b border-border hover:bg-muted/30', // Base styling
-            row.getIsSelected() && 'bg-accent/60 dark:bg-accent/60 text-accent-foreground' // New style for selected rows
+            row.getIsSelected() && 'bg-blue-50 text-slate-900 dark:bg-accent/60 dark:text-accent-foreground' // New distinct styles
           )}>
           {row.getVisibleCells().map((cell) => (
             <CellContextMenu

--- a/src/components/data-grid/data-grid-body.tsx
+++ b/src/components/data-grid/data-grid-body.tsx
@@ -114,8 +114,8 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
               aria-rowindex={virtualItem.index + 2} // +2 because header is row 1
               aria-selected={row.getIsSelected()}
               className={cn(
-                'border-b border-border hover:bg-muted/30', // Base styling
-                row.getIsSelected() && 'bg-blue-50 text-slate-900 dark:bg-accent/60 dark:text-accent-foreground' // New distinct styles
+                'border-b border-border hover:bg-slate-100 dark:hover:bg-slate-800', // Base styling
+                row.getIsSelected() && 'bg-blue-100 text-blue-900 dark:bg-slate-700 dark:text-slate-100' // Updated dark mode selected style
               )}
               style={{
                 position: 'absolute',
@@ -164,8 +164,8 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
           aria-rowindex={row.index + 2} // +2 because header is row 1
           aria-selected={row.getIsSelected()}
           className={cn(
-            'border-b border-border hover:bg-muted/30', // Base styling
-            row.getIsSelected() && 'bg-blue-50 text-slate-900 dark:bg-accent/60 dark:text-accent-foreground' // New distinct styles
+            'border-b border-border hover:bg-slate-100 dark:hover:bg-slate-800', // Base styling
+            row.getIsSelected() && 'bg-blue-100 text-blue-900 dark:bg-slate-700 dark:text-slate-100' // Updated dark mode selected style
           )}>
           {row.getVisibleCells().map((cell) => (
             <CellContextMenu


### PR DESCRIPTION
This pull request introduces a dark mode feature to the `App` component and updates styling to improve consistency across light and dark themes. Key changes include adding theme toggle functionality, enhancing dark mode styles for the `DataGridBody` component, and modifying layout and spacing in the header and footer.

### Dark Mode Implementation:
* Added `theme` state and `toggleTheme` function to enable switching between light and dark modes. Updated `useEffect` to apply the appropriate class to the `document.documentElement` based on the current theme. (`src/App.tsx`, [src/App.tsxR46-R60](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R46-R60))
* Imported `Sun` and `Moon` icons from `lucide-react` for theme toggle button visuals. (`src/App.tsx`, [src/App.tsxL2-R2](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2-R2))

### Header Enhancements:
* Introduced a theme toggle button and GitHub link in the header with relative positioning for better layout. Adjusted padding-top for the main heading. (`src/App.tsx`, [src/App.tsxL496-R532](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L496-R532))

### Footer Modifications:
* Increased footer padding and changed `justify-between` to `justify-center` for a more balanced layout. Removed the GitHub link from the footer. (`src/App.tsx`, [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L678-R716) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L696-R732)

### DataGrid Styling Updates:
* Updated hover and selected row styles in `DataGridBody` to better support dark mode, including color adjustments for background and text. (`src/components/data-grid/data-grid-body.tsx`, [[1]](diffhunk://#diff-6cf3df6dd4ceaacf5d875965d86d2a5d417a86b2f41e07ea01242ecacb895840L117-R118) [[2]](diffhunk://#diff-6cf3df6dd4ceaacf5d875965d86d2a5d417a86b2f41e07ea01242ecacb895840L167-R168)