### PR TITLE
Refactor: Update DataGrid row styling to use semantic Tailwind CSS classes

### DIFF
--- a/src/components/data-grid/data-grid-body.tsx
+++ b/src/components/data-grid/data-grid-body.tsx
@@ -114,9 +114,10 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
               aria-rowindex={virtualItem.index + 2} // +2 because header is row 1
               aria-selected={row.getIsSelected()}
               className={cn(
-                'border-b border-border hover:bg-slate-100 dark:hover:bg-slate-800', // Base styling
-                row.getIsSelected() && 'bg-blue-100 text-blue-900 dark:bg-slate-700 dark:text-slate-100' // Updated dark mode selected style
+                'border-b border-border hover:bg-muted/50', // Base styling
+                row.getIsSelected() && 'data-[state=selected]:bg-accent data-[state=selected]:text-accent-foreground' // Updated dark mode selected style
               )}
+              data-state={row.getIsSelected() ? 'selected' : ''}
               style={{
                 position: 'absolute',
                 top: 0,
@@ -164,9 +165,10 @@ export function DataGridBody({ enableVirtualization = false, estimateSize = 35 }
           aria-rowindex={row.index + 2} // +2 because header is row 1
           aria-selected={row.getIsSelected()}
           className={cn(
-            'border-b border-border hover:bg-slate-100 dark:hover:bg-slate-800', // Base styling
-            row.getIsSelected() && 'bg-blue-100 text-blue-900 dark:bg-slate-700 dark:text-slate-100' // Updated dark mode selected style
-          )}>
+            'border-b border-border hover:bg-muted/50', // Base styling
+            row.getIsSelected() && 'data-[state=selected]:bg-accent data-[state=selected]:text-accent-foreground' // Updated dark mode selected style
+          )}
+          data-state={row.getIsSelected() ? 'selected' : ''}>
           {row.getVisibleCells().map((cell) => (
             <CellContextMenu
               key={cell.id}


### PR DESCRIPTION
This commit updates the row styling in `src/components/data-grid/data-grid-body.tsx` to enhance adherence to shadcn/ui design principles and Tailwind CSS best practices.

- Replaced hardcoded hover styles (e.g., `hover:bg-slate-100`) with the semantic `hover:bg-muted/50` utility class.
- Replaced hardcoded selected row styles (e.g., `bg-blue-100`) with `data-[state=selected]:bg-accent` and `data-[state=selected]:text-accent-foreground`.
- Added the `data-state` attribute to table rows, set to 'selected' when a row is selected, to enable the `data-[state=selected]:` Tailwind variants.

These changes ensure that the data grid's hover and selection appearances are consistent with the overall application theme and will adapt correctly to global style changes, such as light/dark mode toggling, by leveraging Tailwind's theming capabilities.